### PR TITLE
More cross platform

### DIFF
--- a/animgen.py
+++ b/animgen.py
@@ -19,7 +19,7 @@ class AnimGen:
     filepath = None
 
     def __init__(self, filepath):
-        self.filepath = cross_mkdir(filepath + "/animations/")
+        self.filepath = cross_mkdir(os.path.join(filepath, "animations"))
 
     def write(self, scene, node):
         if node.type == 'ARMATURE' and len(scene.gp3d_animations.groups) > 0:
@@ -39,7 +39,7 @@ class AnimGen:
             for lst, temp in zip(ctr_lists, temp_props):
                 temp.strips = [s for s in common_strips if s in lst]
                 
-            animfile = "{0}{1}.animation".format(self.filepath, scene.name)
+            animfile = os.path.join(self.filepath, scene.name + ".animation")
             agg = Aggregator()
             agg.process(temp_props)
             agg.write(scene.frame_end, node.animation_data.nla_tracks, animfile)

--- a/scenegen.py
+++ b/scenegen.py
@@ -23,7 +23,7 @@ class SceneGen:
     cameras = None
 
     def __init__(self, filepath):
-        self.filepath = cross_mkdir(filepath + "/scenes/")
+        self.filepath = cross_mkdir(os.path.join(filepath, "scenes"))
 
     def export(self, scene):
         self.str_scene = "scene {0} {{\n".format(scene.name)
@@ -44,7 +44,7 @@ class SceneGen:
                     self.str_scene += temp
 
         self.str_scene += "}\n"
-        scenefile = "{0}{1}.scene".format(self.filepath, scene.name)
+        scenefile = os.path.join(self.filepath, scene.name + ".scene")
         self.write(self.str_scene, scenefile)
 
     def to_prop(self, scene, tab_num, node):

--- a/utils.py
+++ b/utils.py
@@ -20,13 +20,12 @@ class HomeTab:
     bl_category = 'Gameplay3D'
 
 # return .00n
-def get_suffix(_name):
-    _suffix = re.search(r'\.(\d{3})$', _name)
-    return _suffix
+def get_suffix(name):
+    return os.path.splitext(name)[1]
 
 # return without .00n
-def no_suffix(_name):
-    return _name[:-4] if get_suffix(_name) else _name
+def no_suffix(name):
+    return os.path.splitext(name)[0]
 
 def make_names_unique(collection, item, attribute):
     attrib = getattr(item, attribute) # attribute to make unique
@@ -43,7 +42,7 @@ def make_names_unique(collection, item, attribute):
     setattr(item, attribute, name)
 
 def tabs(num):
-    return ''.join("\t" for i in range(num))
+    return '\t' * num
 
 def deci(n):
     return format(n, '.2f')
@@ -52,14 +51,10 @@ def armature_parent_or_none(obj):
     return obj.parent is None or obj.parent.type == 'ARMATURE'
 
 def cross_mkdir(filepath):
-    if os.name == 'posix':
-        os.system("mkdir -p {0}".format(filepath))
-    else:
-        filepath = filepath.replace('/','\\')
-        os.system("if not exist {0} mkdir {0}".format(filepath))
+    os.makedirs(filepath, exist_ok = True)
     return filepath
 
 class SimpleList(bpy.types.UIList):
     def draw_item(self, context, layout, data, item, icon, active_data, 
-            active_propname, index):
+                  active_propname, index):
         layout.label(text=item.name)


### PR DESCRIPTION
Hi, thanks for the exporter! I made some changes to the scripts to make them a little more cross-platform. Used `os.path` and `shutil` instead of direct OS file commands. Also used `subprocess` instead of `os.system` as this is the preferred Python way to run things.

